### PR TITLE
Make more modest performance claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ slightly more expensive operation that provides better output guarantees. The
 additional overhead (independent of the size of the hashed data) consists of
 performing a wide multiplication instead of a truncated multiplication and one
 additional subtraction. This is very little overhead, and almost doesn't
-register, even when benchmarking the hash function in isolation on integer
-keys.
+register when using ZwoHash in a hash table.
 
 ZwoHash guarantees that any input bit can affect any bit of the output. FxHash
 does not guarantee this, and even beyond that, ZwoHash's output is more

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@
 //! replaces the last iteration with a slightly more expensive operation that provides better output
 //! guarantees. The additional overhead (independent of the size of the hashed data) consists of
 //! performing a wide multiplication instead of a truncated multiplication and one additional
-//! subtraction. This is very little overhead, and almost doesn't register, even when benchmarking
-//! the hash function in isolation on integer keys.
+//! subtraction. This is very little overhead, and almost doesn't register when using ZwoHash in a
+//! hash table.
 //!
 //! ZwoHash guarantees that any input bit can affect any bit of the output. FxHash does not
 //! guarantee this, and even beyond that, ZwoHash's output is more uniform. When used in a hash


### PR DESCRIPTION
While the previous claim was true on the laptop I was developing this
on, I did some more benchmarking on other machines since then, and on
some the overhead when computing hashes in isolation is quite a bit
larger.

Luckily this doesn't change the overall picture when using ZwoHash in a
hash table.